### PR TITLE
fix: clarify Agent.get fallback semantics

### DIFF
--- a/lib/phoenix/socket_client/agent.ex
+++ b/lib/phoenix/socket_client/agent.ex
@@ -60,7 +60,10 @@ defmodule Phoenix.SocketClient.Agent do
   @spec get(pid(), atom() | String.t()) :: any()
   def get(pid, key) do
     Agent.get(pid, fn state ->
-      Map.get(state, key, Map.get(state.custom, key))
+      case Map.fetch(state, key) do
+        {:ok, value} -> value
+        :error -> Map.get(state.custom, key)
+      end
     end)
   end
 


### PR DESCRIPTION
## Summary
- Replaced Map.get with eager default with explicit Map.fetch pattern
- Fallback to custom map only when key is absent from top-level state

Fixes #54