### PR TITLE
fix: resolve struct update warnings

### DIFF
--- a/lib/phoenix/socket_client/agent.ex
+++ b/lib/phoenix/socket_client/agent.ex
@@ -110,7 +110,7 @@ defmodule Phoenix.SocketClient.Agent do
   """
   @spec put(pid(), atom() | String.t(), any()) :: :ok
   def put(pid, key, value) do
-    Agent.update(pid, fn state ->
+    Agent.update(pid, fn %State{} = state ->
       if Map.has_key?(state, key) do
         Map.put(state, key, value)
       else
@@ -133,7 +133,7 @@ defmodule Phoenix.SocketClient.Agent do
   """
   @spec pop_all_to_send(pid()) :: [Message.t()]
   def pop_all_to_send(pid) do
-    Agent.get_and_update(pid, fn state ->
+    Agent.get_and_update(pid, fn %State{} = state ->
       to_send = state.to_send_r |> Enum.reverse()
       {to_send, %State{state | to_send_r: []}}
     end)
@@ -144,7 +144,7 @@ defmodule Phoenix.SocketClient.Agent do
   """
   @spec update_channel_status(pid(), pid(), String.t(), atom(), map() | nil) :: :ok
   def update_channel_status(pid, channel_pid, topic, status, params \\ nil) do
-    Agent.update(pid, fn state ->
+    Agent.update(pid, fn %State{} = state ->
       old_channel_data = Map.get(state.joined_channels, topic, %{})
       old_status = Map.get(old_channel_data, :status)
 
@@ -172,7 +172,7 @@ defmodule Phoenix.SocketClient.Agent do
   """
   @spec remove_channel(pid(), String.t()) :: :ok
   def remove_channel(pid, topic) do
-    Agent.update(pid, fn state ->
+    Agent.update(pid, fn %State{} = state ->
       joined_channels = Map.delete(state.joined_channels, topic)
       %State{state | joined_channels: joined_channels}
     end)

--- a/lib/phoenix/socket_client/channel/helpers.ex
+++ b/lib/phoenix/socket_client/channel/helpers.ex
@@ -30,7 +30,7 @@ defmodule Phoenix.SocketClient.Channel.Helpers do
   """
   def handle_join_call(
         {_pid, _ref} = from,
-        %{sup_pid: sup_pid, topic: topic, params: params} = state
+        %State{sup_pid: sup_pid, topic: topic, params: params} = state
       ) do
     message = Message.join(topic, params)
 
@@ -65,7 +65,7 @@ defmodule Phoenix.SocketClient.Channel.Helpers do
   def handle_push_call(
         {event, payload},
         from,
-        %{sup_pid: sup_pid, topic: topic} = state
+        %State{sup_pid: sup_pid, topic: topic} = state
       ) do
     message = %Message{
       topic: topic,
@@ -113,7 +113,7 @@ defmodule Phoenix.SocketClient.Channel.Helpers do
   """
   def handle_phx_reply_info(
         %Message{event: "phx_reply", ref: ref} = msg,
-        %{pushes: pushes, topic: topic, join_ref: join_ref, params: params} = s,
+        %State{pushes: pushes, topic: topic, join_ref: join_ref, params: params} = s,
         _handle_message_fun,
         handle_join_reply_fun \\ nil
       ) do
@@ -126,7 +126,7 @@ defmodule Phoenix.SocketClient.Channel.Helpers do
 
           new_state =
             if ref == join_ref && handle_join_reply_fun do
-              {:noreply, updated} =
+              {:noreply, %State{} = updated} =
                 handle_join_reply_fun.(status_to_atom(status), response, s)
 
               updated

--- a/lib/phoenix/socket_client/socket.ex
+++ b/lib/phoenix/socket_client/socket.ex
@@ -264,7 +264,7 @@ defmodule Phoenix.SocketClient.Socket do
 
   @impl true
   @spec handle_info(:flush, t()) :: {:noreply, t()}
-  def handle_info(:flush, %{sup_pid: _sup_pid} = state) do
+  def handle_info(:flush, %__MODULE__{sup_pid: _sup_pid} = state) do
     to_send = state.to_send_r || []
 
     state =
@@ -641,7 +641,7 @@ defmodule Phoenix.SocketClient.Socket do
     end
   end
 
-  defp close(reason, %{sup_pid: sup_pid} = state) do
+  defp close(reason, %__MODULE__{sup_pid: sup_pid} = state) do
     # Cancel heartbeat timer if active
     if state.heartbeat_timer do
       Process.cancel_timer(state.heartbeat_timer)


### PR DESCRIPTION
## Summary
- Pattern match socket client state before struct updates in Agent callbacks
- Pattern match channel and socket states before struct updates
- Verified compile with warnings as errors and full test suite

Fixes #98