### PR TITLE
fix: close transport on disconnect

### DIFF
--- a/lib/phoenix/socket_client/socket.ex
+++ b/lib/phoenix/socket_client/socket.ex
@@ -649,6 +649,7 @@ defmodule Phoenix.SocketClient.Socket do
 
     socket_state = Phoenix.SocketClient.get_state(sup_pid)
     socket_ref = Phoenix.SocketClient.get_state(sup_pid, :socket_ref)
+    close_transport(socket_state, state)
 
     # Update socket state status
     update_socket_state_status(sup_pid, :disconnected)
@@ -668,8 +669,26 @@ defmodule Phoenix.SocketClient.Socket do
       Process.send_after(self(), :connect, socket_state.reconnect_interval)
     end
 
-    %__MODULE__{state | status: :disconnected, heartbeat_timer: nil}
+    %__MODULE__{
+      state
+      | status: :disconnected,
+        heartbeat_timer: nil,
+        transport_pid: nil,
+        transport_ref: nil,
+        connect_start_time: nil
+    }
   end
+
+  defp close_transport(%{transport: transport}, %{
+         transport_pid: transport_pid,
+         transport_ref: ref
+       })
+       when is_pid(transport_pid) do
+    if ref, do: Process.demonitor(ref, [:flush])
+    transport.close(transport_pid)
+  end
+
+  defp close_transport(_socket_state, _state), do: :ok
 
   defp update_socket_state_status(sup_pid, new_status) do
     old_status = get_state(sup_pid, :status)

--- a/test/phoenix/socket_client/disconnect_test.exs
+++ b/test/phoenix/socket_client/disconnect_test.exs
@@ -1,0 +1,77 @@
+defmodule Phoenix.SocketClient.DisconnectTest do
+  use ExUnit.Case, async: false
+
+  defmodule CloseTrackingTransport do
+    @behaviour Phoenix.SocketClient.Transport
+
+    @impl true
+    def open(_url, opts) do
+      test_pid = Keyword.fetch!(opts, :test_pid)
+      sender = Keyword.fetch!(opts, :sender)
+
+      transport_pid =
+        spawn(fn ->
+          send(test_pid, {:transport_opened, self()})
+          send(sender, {:connected, self()})
+
+          receive do
+            :close -> send(test_pid, {:transport_closed, self()})
+          after
+            5_000 -> :ok
+          end
+        end)
+
+      {:ok, transport_pid}
+    end
+
+    @impl true
+    def close(pid) when is_pid(pid) do
+      send(pid, :close)
+      :ok
+    end
+  end
+
+  test "disconnect closes the active transport process" do
+    name = :"disconnect_transport_#{System.unique_integer([:positive])}"
+
+    start_supervised!(
+      {Phoenix.SocketClient,
+       name: name,
+       url: "ws://example.invalid/socket/websocket",
+       auto_connect: false,
+       reconnect: false,
+       transport: CloseTrackingTransport,
+       transport_opts: [test_pid: self()]}
+    )
+
+    assert :ok = Phoenix.SocketClient.connect(name)
+    assert_receive {:transport_opened, transport_pid}
+    transport_ref = Process.monitor(transport_pid)
+
+    assert eventually(fn -> Phoenix.SocketClient.connected?(name) end)
+
+    assert :ok = Phoenix.SocketClient.disconnect(name)
+    assert_receive {:transport_closed, ^transport_pid}
+    assert_receive {:DOWN, ^transport_ref, :process, ^transport_pid, :normal}
+    refute Phoenix.SocketClient.connected?(name)
+
+    socket_pid = Phoenix.SocketClient.get_process_pid(name, :socket)
+    socket_state = GenServer.call(socket_pid, :get_state)
+
+    assert socket_state.status == :disconnected
+    assert socket_state.transport_pid == nil
+    assert socket_state.transport_ref == nil
+  end
+
+  defp eventually(fun, attempts \\ 20)
+  defp eventually(fun, 0), do: fun.()
+
+  defp eventually(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(10)
+      eventually(fun, attempts - 1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Close the configured transport when socket close/disconnect runs
- Clear stale transport pid/ref/connect timestamp from socket state
- Add a regression test that proves disconnect closes the active transport process

Fixes #97