### PR TITLE
fix: cover websocket header forwarding

### DIFF
--- a/test/phoenix/socket_client/headers_test.exs
+++ b/test/phoenix/socket_client/headers_test.exs
@@ -1,0 +1,37 @@
+defmodule Phoenix.SocketClient.HeadersTest do
+  use ExUnit.Case, async: false
+
+  alias Phoenix.SocketClient.Channel
+
+  test "configured websocket headers are sent during the handshake" do
+    name = :"headers_#{System.unique_integer([:positive])}"
+    port = Application.get_env(:phoenix_socket_client_test, :port)
+
+    {:ok, _pid} =
+      Phoenix.SocketClient.start_link(
+        name: name,
+        url: "ws://127.0.0.1:#{port}/ws/admin/websocket",
+        headers: [{"x-backplane-host-token", "secret-token"}]
+      )
+
+    wait_for_socket(name)
+
+    assert {:ok, headers, _channel} = Channel.join(name, "rooms:headers")
+    assert headers["x-backplane-host-token"] == "secret-token"
+  end
+
+  defp wait_for_socket(socket_name, retries \\ 50)
+
+  defp wait_for_socket(_socket_name, 0) do
+    raise "Socket did not connect after waiting"
+  end
+
+  defp wait_for_socket(socket_name, retries) do
+    if Phoenix.SocketClient.connected?(socket_name) do
+      :ok
+    else
+      Process.sleep(100)
+      wait_for_socket(socket_name, retries - 1)
+    end
+  end
+end

--- a/test/support/mock_server.ex
+++ b/test/support/mock_server.ex
@@ -94,7 +94,9 @@ defmodule Phoenix.SocketClientTest.Endpoint do
     signing_salt: "test_salt"
   ]
 
-  socket("/ws/admin", Phoenix.SocketClientTest.AdminSocket, websocket: [check_origin: false])
+  socket("/ws/admin", Phoenix.SocketClientTest.AdminSocket,
+    websocket: [check_origin: false, connect_info: [:x_headers]]
+  )
 
   # Add this plug to handle basic HTTP requests
   plug(Plug.RequestId)
@@ -123,10 +125,17 @@ defmodule Phoenix.SocketClientTest.AdminSocket do
   channel("test:*", Phoenix.SocketClientTest.RoomChannel)
 
   def connect(params, socket, connect_info) do
+    headers =
+      connect_info
+      |> Map.get(:x_headers, [])
+      |> Map.new(fn {key, value} -> {String.downcase(to_string(key)), to_string(value)} end)
+
     on_connect(self(), %{
       params: params,
       connect_info: connect_info
     })
+
+    socket = assign(socket, :headers, headers)
 
     {:ok, socket}
   end


### PR DESCRIPTION
## Summary
- Enable x-header connect info in the test Phoenix socket
- Store handshake x-headers in socket assigns for assertions
- Add an integration regression proving configured websocket headers are forwarded

Fixes #95